### PR TITLE
Change wording of Information collection section

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -10,9 +10,9 @@ We use this data to find out who you know, and in turn, who those people know. W
 This requires a level of trust on your part, and this is something that we do not take lightly. 
 </p>
 <p>
-<h2>Information we collect</h2>
+<h2>Information we collect when you use Cohort</h2>
 <ul>
-	<li>What you give us</li>
+	<li>What you give us from your data sources</li>
 	<li>What we get from your use of Cohort</li>
     <ul>
 			<li>We use Google Analytics to track aggregated activity across our web interfaces</li>
@@ -28,7 +28,7 @@ We use this information to build, maintain and improve the Cohort service. We do
 <h2>Our Privacy Principles</h2>
 <ol>
 	<li>Your data is your data - any data that you bring to the party on signup remains yours.</li>
-	<li>You can remove this data yourself from Cohort at any time. While there is no automated way to do this right now, this is a feature that is on our roadmap and will be built in due course. In the meantime, if you want your public data removed from Cohort, please email <a href="mailto:privacy@cohort.is">privacy@cohort.is</a> </li>
+	<li>You can remove this data yourself from Cohort at any time. While there is no automated way to do this right now, this is a feature that is on our roadmap and will be built in due course. In the meantime, if you want your personal data removed from Cohort, please email <a href="mailto:privacy@cohort.is">privacy@cohort.is</a> </li>
 	<li>Any data that’s generated from your use of Cohort belongs to Cohort, as optimal operation of the service relies on it, but it will be available for you to download at any time. While this is not yet a feature, it is planned. In the meantime, if you want a copy of your usage data, please email <a href="mailto:privacy@cohort.is">privacy@cohort.is</a></li>
 	<li>Here is a list of all the things we currently collect on you and your use of Cohort</li>
 		<ol>


### PR DESCRIPTION
Information collection now more explicit that information collection listed is when they use Cohort, as other information (public Twitter data for example) is collected regardless of their use of the system.

Also changed 'public' to 'personal' in the section on data removal, as it specifies the personal data the person brings to the system, and not the ambient data that is collected from public sources.
